### PR TITLE
docs: fixed a typo in content/getting_started/Faq.md

### DIFF
--- a/content/getting_started/Faq.md
+++ b/content/getting_started/Faq.md
@@ -25,7 +25,7 @@ opt input.ll -load=/path/to/LLVMEnzyme-VERSION.so -enzyme -o output.ll -S
 `
 opt reports a error:`opt: unknown pass name 'enzyme'`
 
-May be beacause you are using  LLVM 13 or a higher version, which has switched to the new pass manager pipeline and we haven't yet turned that on within enzyme.
+May be because you are using  LLVM 13 or a higher version, which has switched to the new pass manager pipeline and we haven't yet turned that on within enzyme.
 For now you can just tell llvm to use the old pass manager by adding the `--enable-new-pm=0` flag to opt or `-flegacy-pass-manager` to clang.
 
 ### UNREACHABLE executed (GVN error)


### PR DESCRIPTION
fixed a typo in `content/getting_started/Faq.md`
Signed-off-by: Girish Joshi <girish946@gmail.com>