### PR TITLE
Clean up of "Getting Involved"

### DIFF
--- a/content/getting_involved/_index.md
+++ b/content/getting_involved/_index.md
@@ -5,7 +5,7 @@ draft: false
 weight: 15
 ---
 
-Enzyme is a project for high-performance automatic differentiation. The Enzyme community aims to be open and welcoming. If you'd like to participate, you can do so in a number of ways:
+The Enzyme community aims to be open and welcoming, and as an LLVM Incubator Project we follow the [LLVM Community Code of Conduct](https://llvm.org/docs/CodeOfConduct.html). If you'd like to participate, you can do so in a number of ways:
 
 * Join our [mailing list](https://groups.google.com/d/forum/enzyme-dev)
 * Join our weekly [open-design call](https://mit.zoom.us/j/96000853439)


### PR DESCRIPTION
Making the wording around how to get involved a bit more clearer, and point to the LLVM community code of conduct.