### PR TITLE
(WIP) add new page with more C++ examples

### DIFF
--- a/content/getting_started/Examples.md
+++ b/content/getting_started/Examples.md
@@ -1,0 +1,199 @@
+---
+title: "C++ Examples"
+date: 2023-07-25
+draft: false
+weight: 25
+katex: true
+---
+
+There are many ways to implement a given calculation. This document contains examples of how to apply Enzyme to different kinds of patterns that show up frequently in C++. To make the code snippets below more concise, we'll assume that each example snippet has the following definitions prepended to the translation unit:
+
+```cpp
+int enzyme_dup;
+int enzyme_dupnoneed;
+int enzyme_out;
+int enzyme_const;
+
+template < typename return_type, typename ... T >
+extern return_type __enzyme_fwddiff(void*, T ... );
+
+template < typename return_type, typename ... T >
+extern return_type __enzyme_autodiff(void*, T ... );
+```
+
+
+
+## Free Functions: Return-By-Value
+
+Consider a function with one scalar input and one scalar output, \\(f(x) \coloneqq x^2.\\) We can implement this in C++ as a free function:
+
+```cpp
+double f(double x) { return x * x; }
+```
+
+The derivative of this function is simply \\(f'(x) = 2x\\), but rather than implement that by hand, let's see how do it with automatically with Enzyme:
+
+```cpp
+double x = 5.0;
+double dx = 1.0;
+double df_dx = __enzyme_fwddiff<double>((void*)f, enzyme_dup, x, dx); 
+printf("f(x) = %f, f'(x) = %f", f(x), df_dx);
+// prints f(x) = 25.000000, f'(x) = 10.000000
+```
+
+So, we first tell enzyme which function we want to differentiate and then pass arguments the arguments following `enzyme_dup` are telling enzyme where to evaluate the derivative and how much to scale the derivative (we pick `dx = 1.0` to have unit scale). 
+
+Link to example: https://fwd.gymni.ch/yeLDzF
+
+--------
+
+Next, we'll look at a function with two inputs and one output,
+$$
+f(x, y) \coloneqq x \\, y + \frac{1}{y}
+$$
+
+The "derivative" (i.e. the Jacobian) of this function is a row vector with two entries:
+$$
+\bold{J} = \left[
+\begin{array}{cc}
+\displaystyle \frac{\partial f}{\partial x} & \displaystyle \frac{\partial f}{\partial y}
+\end{array}
+\right]
+$$
+There are two fundamental operations that involve the Jacobian:
+
+1. "forward mode" differentiation: compute \\(df := \bold{J} \cdot d\bold{x}\\), (where \\(d\bold{x} = [dx \\,\\,  dy]^\top\\))
+2. "reverse mode" differentiation: compute \\(\boldsymbol{\mu} := \bold{J}^\top  \lambda\\\)
+
+There's lots more to say here about when to use forward mode or reverse mode, but that's beyond the scope of this document, so we'll just focus on how to use Enzyme to perform these two kinds of differentiation for us.
+
+Like before, start by implementing the original function
+
+```cpp
+double f(double x, double y) { return x * y + 1.0 / y; }
+```
+
+#### Forward Mode
+
+`__enzyme_fwddiff` implements forward-mode differentiation, and we use it by specifying where to evaluate \\(\bold{J}\\), and what values to use for \\(d\bold{x}\\)
+
+```cpp
+double x = 3.0;
+double y = 2.0;
+double dx = 1.0;
+double dy = 1.0;
+double df = __enzyme_fwddiff<double>((void*)f, enzyme_dup, x, dx, enzyme_dup, y, dy); 
+printf("f(x) = %f, df = %f", f(x, y), df)
+// prints f(x) = 6.500000, df = 4.750000
+```
+
+> But what if I only want to (forward) differentiate with respect to some of the inputs? 
+
+There are two approaches:
+
+1. Set `dx` or `dy` to zeroes as needed for unwanted derivatives
+
+   ```cpp
+   double dfdx = __enzyme_fwddiff<double>((void*)f, enzyme_dup, x, 1.0, enzyme_dup, y, 0.0); 
+   double dfdy = __enzyme_fwddiff<double>((void*)f, enzyme_dup, x, 0.0, enzyme_dup, y, 1.0); 
+   printf("dfdx = %f, dfdy = %f\n", dfdx, dfdy);
+   // prints dfdx = 2.000000, dfdy = 2.750000
+   ```
+
+2. Specify `enzyme_const` to indicate which arguments are not to be differentiated
+   ```cpp
+   double dfdx = __enzyme_fwddiff<double>((void*)f, enzyme_dup, x, 1.0, enzyme_const, y); 
+   double dfdy = __enzyme_fwddiff<double>((void*)f, enzyme_const, x, enzyme_dup, y, 1.0); 
+   printf("dfdx = %f, dfdy = %f\n", dfdx, dfdy);
+   // prints dfdx = 2.000000, dfdy = 2.750000
+   ```
+
+Option 1 has the benefit of flexibility-- we can choose to turn differentiation with respect to certain variables on or off at runtime. Option 2 hard codes which derivatives can be computed, which narrows scope and potentially improves performance. The appropriate choice will depend on the specific needs of your project.
+
+Link to example: https://fwd.gymni.ch/xoTj9R
+
+#### Reverse Mode
+
+`__enzyme_autodiff` implements reverse-mode differentiation. We tell enzyme which function to differentiate, and pass information about where to evaluate the Jacobian. The `enzyme_out` specifier indicates which components (i.e. rows of the vector-jacobian product \\(\bold{J}^\top \lambda\\)) we want
+
+```cpp
+struct double2{ double x, y; };
+
+...
+
+double x = 3.0;
+double y = 2.0;
+auto [mu_x, mu_y] = __enzyme_autodiff<double2>((void*)f, enzyme_out, x, enzyme_out, y); 
+printf("mu_x = %f, mu_y = %f\n", mu_x, mu_y);
+// prints mu_x = 2.000000, mu_y = 2.750000
+```
+
+The value returned by `__enzyme_autodiff` is the concatenation of the different `enzyme_out` quantities. Here, we define a struct, `double2` to represent those output values (and use C++17 structured binding to split them into `mu_x, mu_y`).
+
+> Note: it may be tempting to store the outputs in a `std::tuple< double, double >`, but the memory layout of `std::tuple` is implementation defined (e.g. some compilers implement `std::tuple<T, U, V>` with `V` first, `U` second, and `T` last). So, please don't store the outputs of `__enzyme_autodiff` in a `std::tuple`!
+
+Link to example: https://fwd.gymni.ch/gPPXUg
+
+## Free Functions: Return-By-Reference
+
+Another possible way to implement the previous function is with an out-parameter:
+
+```cpp
+void f(double x, double y, double & output) { output = x * y + 1.0 / y; }
+```
+
+Differentiating functions like this with enzyme is similar to the return-by-value case, but with some small differences. 
+
+If we only care about the derivative output, and not the function value itself, we can use the `enzyme_dupnoneed` descriptor. This lets the compiler optimize away unnecessary calculations associated with evaluating the output.
+
+#### Forward Mode
+
+```cpp
+// these will be overwritten by __enzyme_fwddiff
+double z = 0;
+double dz = 0;
+#if 1
+__enzyme_fwddiff<void>((void*)f, enzyme_dup, x, dx, 
+                                 enzyme_dup, y, dy, 
+                                 enzyme_dup, &z, &dz);
+printf("f(x,y) = %f, df = %f\n", z, dz);
+// prints f(x,y) = 6.500000, df = 7.500000
+#else
+__enzyme_fwddiff<void>((void*)f, enzyme_dup, x, dx, 
+                                 enzyme_dup, y, dy, 
+                                 enzyme_dupnoneed, &z, &dz);
+printf("f(x,y) = %f, df = %f\n", z, dz);
+// prints f(x,y) = 0.000000, df = 7.500000
+#endif
+```
+
+Note: the by-reference arguments of the function are passed to `__enzyme_fwddiff` by address. 
+
+Link to example: https://fwd.gymni.ch/Uxo2JG
+
+#### Reverse Mode
+
+vector-Jacobian product  \\(\boldsymbol{\mu} := \bold{J}^\top  \lambda\\\) is implemented as
+
+```cpp
+// lambda is an input to __enzyme_autodiff 
+double lambda = 2.0;
+#if 1
+double2 mu = __enzyme_autodiff<double2>((void*)f, enzyme_out, x, 
+                                                  enzyme_out, y, 
+                                                  enzyme_dup, &z, &lambda); 
+printf("z = %f, mu.x = %f, mu.y = %f\n", z, mu.x, mu.y);
+// prints z = 6.500000, mu.x = 4.000000, mu.y = 5.500000
+#else
+double2 mu = __enzyme_autodiff<double2>((void*)f, enzyme_out, x, 
+                                                  enzyme_out, y, 
+                                                  enzyme_dupnoneed, &z, &lambda); 
+printf("z = %f, mu.x = %f, mu.y = %f\n", z, mu.x, mu.y);
+// prints z = 0.000000, mu.x = 4.000000, mu.y = 5.500000
+#endif
+```
+
+Link to example: https://fwd.gymni.ch/sfY5uu
+
+
+

--- a/themes/mlir/layouts/partials/footer.html
+++ b/themes/mlir/layouts/partials/footer.html
@@ -9,3 +9,5 @@
 <i class="fas fa-circle"></i>
 <i class="fas fa-arrow-circle-up"></i>
 </span></a>
+
+{{ if .Params.katex}}{{ partial "katex.html" . }}{{ end }}

--- a/themes/mlir/layouts/partials/katex.html
+++ b/themes/mlir/layouts/partials/katex.html
@@ -1,0 +1,8 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
+
+<!-- The loading of KaTeX is deferred to speed up page rendering -->
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
+
+<!-- To automatically render math in text elements, include the auto-render extension: -->
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js" integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous"
+    onload="renderMathInElement(document.body);"></script>


### PR DESCRIPTION
Goal: provide more examples and explanations of how to use Enzyme to differentiate (forward mode and reverse mode) a handful of common C++ function types
- free functions
- function templates (WIP)
- member functions (WIP)
- functors (WIP)
- lambdas (WIP)

with respect to pass-by-value arguments, pass-by-reference arguments and member variables.

-----
 
Also adds katex support for LaTeX rendering.

I think it'd be good to also document the instructions to build the site locally (essentially just download `hugo` and execute `hugo server`) to encourage contributions.