### PR TITLE
more C++ examples, update MLIR theme

### DIFF
--- a/content/getting_started/Examples.md
+++ b/content/getting_started/Examples.md
@@ -15,10 +15,10 @@ int enzyme_out;
 int enzyme_const;
 
 template < typename return_type, typename ... T >
-extern return_type __enzyme_fwddiff(void*, T ... );
+return_type __enzyme_fwddiff(void*, T ... );
 
 template < typename return_type, typename ... T >
-extern return_type __enzyme_autodiff(void*, T ... );
+return_type __enzyme_autodiff(void*, T ... );
 ```
 
 
@@ -44,7 +44,7 @@ printf("f(x) = %f, f'(x) = %f", f(x), df_dx);
 The first argument tells enzyme which function we want to differentiate, and the subsequent 
 arguments describe where to evaluate the derivatve and in what "direction".
 
-Link to example: https://fwd.gymni.ch/yeLDzF
+Link to example: https://fwd.gymni.ch/Hx6hwt
 
 --------
 
@@ -111,7 +111,7 @@ There are two approaches:
 
 Option 1 has the benefit of flexibility-- we can choose to turn differentiation with respect to certain variables on or off at runtime. Option 2 hard codes which derivatives can be computed, which narrows scope and potentially improves performance. The appropriate choice will depend on the specific needs of your project.
 
-Link to example: https://fwd.gymni.ch/xoTj9R
+Link to example: https://fwd.gymni.ch/OJMdAx
 
 #### Reverse Mode
 
@@ -133,7 +133,7 @@ The value returned by `__enzyme_autodiff` is the concatenation of the different 
 
 > Note: it may be tempting to store the outputs in a `std::tuple< double, double >`, but the memory layout of `std::tuple` is implementation defined (e.g. some compilers implement `std::tuple<T, U, V>` with `V` first, `U` second, and `T` last). So, please don't store the outputs of `__enzyme_autodiff` in a `std::tuple`!
 
-Link to example: https://fwd.gymni.ch/gPPXUg
+Link to example: https://fwd.gymni.ch/HMFTsY
 
 ## Free Functions: Return-By-Reference
 
@@ -170,7 +170,7 @@ printf("f(x,y) = %f, df = %f\n", z, dz);
 
 Note: the by-reference arguments of the function are passed to `__enzyme_fwddiff` by address. 
 
-Link to example: https://fwd.gymni.ch/Uxo2JG
+Link to example: https://fwd.gymni.ch/BtpzAA
 
 #### Reverse Mode
 
@@ -194,7 +194,7 @@ printf("z = %f, mu.x = %f, mu.y = %f\n", z, mu.x, mu.y);
 #endif
 ```
 
-Link to example: https://fwd.gymni.ch/sfY5uu
+Link to example: https://fwd.gymni.ch/eYmIzw
 
 
 ### Function Templates
@@ -216,7 +216,7 @@ __enzyme_fwddiff<void>((void*)f<double>, enzyme_dup, x, dx,
                                          enzyme_dupnoneed, &z, &dz);
 ```
 
-Link to example: https://fwd.gymni.ch/BOjhY4
+Link to example: https://fwd.gymni.ch/WJVVRt
 
 
 ## Member Functions
@@ -274,7 +274,7 @@ When passing information to `__enzyme_autodiff`, `__enzyme_fwddiff`:
 - if the differentiated function takes an argument by value, then we pass it to enzyme by value
 - if the differentiated function takes an argument by pointer, reference or rvalue-ref, then we pass it to enzyme by pointer
 
-Link to example: https://fwd.gymni.ch/qNOtQN
+Link to example: https://fwd.gymni.ch/y0scib
 
 
 
@@ -288,7 +288,7 @@ double dfdx = __enzyme_fwddiff<double>((void*)wrapper<MyObject, double>,
 printf("dfdx = %f\n", dfdx);
 ```
 
-Link to example: https://fwd.gymni.ch/RgVcj5
+Link to example: https://fwd.gymni.ch/wlC87F
 
 
 
@@ -395,7 +395,7 @@ This means there are a few ways to differentiate this kind of lambda function:
 
 
 
-Link to examples: https://fwd.gymni.ch/tSRmyq
+Link to examples: https://fwd.gymni.ch/wkgeoL
 
 ------
 

--- a/themes/mlir/layouts/partials/head.html
+++ b/themes/mlir/layouts/partials/head.html
@@ -11,22 +11,33 @@
 {{- else if isset .Site.Params "description" }}
 <meta name="description" content="{{ .Site.Params.description }}">
 {{- end }}
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 <link href="{{ .Site.BaseURL }}index.xml" rel="alternate" type="application/rss+xml">
 <link rel="canonical" href="{{ .Permalink }}">
-<link rel="stylesheet" href="{{"/css/theme.css" | absURL}}">
+<link rel="stylesheet" href="{{"css/theme.css" | absURL}}">
 <script src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
 {{ partial "meta/chroma.html" . -}}
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery.easing@1.4.1/jquery.easing.min.js"></script>
 <script src="{{"js/bundle.js" | absURL}}"></script>
-
-<link rel="apple-touch-icon" sizes="180x180" href="/favicon_io/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/favicon_io/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/favicon_io/favicon-16x16.png">
-<link rel="manifest" href="/favicon_io/site.webmanifest">
-
-<script defer data-domain="enzyme.mit.edu" src="https://plausible.io/js/plausible.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    tex2jax: {
+      inlineMath: [['$', '$'] ],
+      displayMath: [ ['$$','$$'], ["\\[","\\]"] ]
+    }
+  });
+</script>
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=1">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=1">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=1">
+<link rel="manifest" href="/site.webmanifest?v=1">
+<link rel="mask-icon" href="/safari-pinned-tab.svg?v=1" color="#3775e0">
+<link rel="shortcut icon" href="/favicon.ico?v=1">
+<meta name="msapplication-TileColor" content="#2d89ef">
+<meta name="theme-color" content="#ffffff">
+<link rel="icon" href="/favicon.svg" type="image/svg+xml" sizes="any">
 {{- partial "meta/google-analytics-async.html" . -}}
 {{- partial "meta/tag-manager.html" . -}}
 {{- partial "meta/google-site-verification.html" . -}}

--- a/themes/mlir/layouts/partials/menu/slide-menu.html
+++ b/themes/mlir/layouts/partials/menu/slide-menu.html
@@ -22,7 +22,7 @@
 {{- else -}}
   {{- safeHTML .Params.head -}}
   {{- $numberOfPages := (add (len .Pages) (len .Sections)) -}}
-<li class="{{ if .IsAncestor $currentNode }}parent{{ end }}{{ if eq .UniqueID $currentNode.UniqueID }} active{{ end }}{{ if ne $numberOfPages 0 }} has-sub-menu{{ end }}"><a href="{{ .URL }}">{{ safeHTML .Params.Pre }}{{ .Title }}{{ safeHTML .Params.Post }}{{ if ne $numberOfPages 0 }}{{ if .IsAncestor $currentNode }}<span class="mark opened">-</span>{{ else }}<span class="mark closed">+</span>{{ end }}{{ end }}</a>
+<li class="{{ if .IsAncestor $currentNode }}parent{{ end }}{{ if eq .File.UniqueID $currentNode.File.UniqueID }} active{{ end }}{{ if ne $numberOfPages 0 }} has-sub-menu{{ end }}"><a href="{{ .Permalink }}">{{ safeHTML .Params.Pre }}{{ .Title }}{{ safeHTML .Params.Post }}{{ if ne $numberOfPages 0 }}{{ if .IsAncestor $currentNode }}<span class="mark opened">-</span>{{ else }}<span class="mark closed">+</span>{{ end }}{{ end }}</a>
   {{ if ne $numberOfPages 0 }}
 <ul class="sub-menu">
     {{- .Scratch.Set "pages" .Pages -}}
@@ -51,7 +51,7 @@
 {{- end -}}
 {{- else -}}
   {{- if not .Params.Hidden -}}
-<li class="{{ if eq .UniqueID $currentNode.UniqueID }}active{{ end }}"><a href="{{ .URL }}">{{ safeHTML .Params.Pre }}{{ .Title }}{{ safeHTML .Params.Post }}</a></li>
+<li class="{{ if eq .File.UniqueID $currentNode.File.UniqueID }}active{{ end }}"><a href="{{ .Permalink }}">{{ safeHTML .Params.Pre }}{{ .Title }}{{ safeHTML .Params.Post }}</a></li>
   {{- end -}}
 {{ end -}}
 {{ end -}}

--- a/themes/mlir/layouts/partials/menu/slide-menu.html
+++ b/themes/mlir/layouts/partials/menu/slide-menu.html
@@ -22,7 +22,7 @@
 {{- else -}}
   {{- safeHTML .Params.head -}}
   {{- $numberOfPages := (add (len .Pages) (len .Sections)) -}}
-<li class="{{ if .IsAncestor $currentNode }}parent{{ end }}{{ if eq .File.UniqueID $currentNode.File.UniqueID }} active{{ end }}{{ if ne $numberOfPages 0 }} has-sub-menu{{ end }}"><a href="{{ .Permalink }}">{{ safeHTML .Params.Pre }}{{ .Title }}{{ safeHTML .Params.Post }}{{ if ne $numberOfPages 0 }}{{ if .IsAncestor $currentNode }}<span class="mark opened">-</span>{{ else }}<span class="mark closed">+</span>{{ end }}{{ end }}</a>
+<li class="{{ if .IsAncestor $currentNode }}parent{{ end }}{{ if eq .File.UniqueID $currentNode.File.UniqueID }} active{{ end }}{{ if ne $numberOfPages 0 }} has-sub-menu{{ end }}"><a href="{{ .RelPermalink }}">{{ safeHTML .Params.Pre }}{{ .Title }}{{ safeHTML .Params.Post }}{{ if ne $numberOfPages 0 }}{{ if .IsAncestor $currentNode }}<span class="mark opened">-</span>{{ else }}<span class="mark closed">+</span>{{ end }}{{ end }}</a>
   {{ if ne $numberOfPages 0 }}
 <ul class="sub-menu">
     {{- .Scratch.Set "pages" .Pages -}}
@@ -51,7 +51,7 @@
 {{- end -}}
 {{- else -}}
   {{- if not .Params.Hidden -}}
-<li class="{{ if eq .File.UniqueID $currentNode.File.UniqueID }}active{{ end }}"><a href="{{ .Permalink }}">{{ safeHTML .Params.Pre }}{{ .Title }}{{ safeHTML .Params.Post }}</a></li>
+<li class="{{ if eq .File.UniqueID $currentNode.File.UniqueID }}active{{ end }}"><a href="{{ .RelPermalink }}">{{ safeHTML .Params.Pre }}{{ .Title }}{{ safeHTML .Params.Post }}</a></li>
   {{- end -}}
 {{ end -}}
 {{ end -}}

--- a/themes/mlir/layouts/partials/pagination.html
+++ b/themes/mlir/layouts/partials/pagination.html
@@ -2,10 +2,10 @@
 <nav class="pagination">
 {{- template "pagination" dict "menu" .Site.Home "currentnode" $currentNode "menu_exclusion" .Site.Params.menu_exclusion -}}
 {{- with ($.Scratch.Get "prevPage") -}}
-<a class="nav nav-prev" href="{{ .URL }}" title="{{ .Title }}"><i class="fas fa-arrow-left" aria-hidden="true"></i> Prev - {{ .Title }}</a>
+<a class="nav nav-prev" href="{{ .Permalink }}" title="{{ .Title }}"><i class="fas fa-arrow-left" aria-hidden="true"></i> Prev - {{ .Title }}</a>
 {{ end -}}
 {{- with ($.Scratch.Get "nextPage") -}}
-<a class="nav nav-next" href="{{ .URL }}" title="{{ .Title }}">Next - {{ .Title }} <i class="fas fa-arrow-right" aria-hidden="true"></i></a>
+<a class="nav nav-next" href="{{ .Permalink }}" title="{{ .Title }}">Next - {{ .Title }} <i class="fas fa-arrow-right" aria-hidden="true"></i></a>
 {{- end }}
 </nav>
 
@@ -13,7 +13,7 @@
 {{- $currentNode := .currentnode -}}
 {{- $menu_exclusion := .menu_exclusion -}}
 
-{{- if hasPrefix $currentNode.URL .menu.URL -}}
+{{- if hasPrefix $currentNode.Permalink .menu.Permalink -}}
   {{- $currentNode.Scratch.Set "NextPageOK" "OK" -}}
   {{- if .menu.IsHome -}}
     {{- $currentNode.Scratch.Set "prevPage" "" -}}

--- a/themes/mlir/layouts/partials/pagination.html
+++ b/themes/mlir/layouts/partials/pagination.html
@@ -2,10 +2,10 @@
 <nav class="pagination">
 {{- template "pagination" dict "menu" .Site.Home "currentnode" $currentNode "menu_exclusion" .Site.Params.menu_exclusion -}}
 {{- with ($.Scratch.Get "prevPage") -}}
-<a class="nav nav-prev" href="{{ .Permalink }}" title="{{ .Title }}"><i class="fas fa-arrow-left" aria-hidden="true"></i> Prev - {{ .Title }}</a>
+<a class="nav nav-prev" href="{{ .RelPermalink }}" title="{{ .Title }}"><i class="fas fa-arrow-left" aria-hidden="true"></i> Prev - {{ .Title }}</a>
 {{ end -}}
 {{- with ($.Scratch.Get "nextPage") -}}
-<a class="nav nav-next" href="{{ .Permalink }}" title="{{ .Title }}">Next - {{ .Title }} <i class="fas fa-arrow-right" aria-hidden="true"></i></a>
+<a class="nav nav-next" href="{{ .RelPermalink }}" title="{{ .Title }}">Next - {{ .Title }} <i class="fas fa-arrow-right" aria-hidden="true"></i></a>
 {{- end }}
 </nav>
 
@@ -13,7 +13,7 @@
 {{- $currentNode := .currentnode -}}
 {{- $menu_exclusion := .menu_exclusion -}}
 
-{{- if hasPrefix $currentNode.Permalink .menu.Permalink -}}
+{{- if hasPrefix $currentNode.RelPermalink .menu.RelPermalink -}}
   {{- $currentNode.Scratch.Set "NextPageOK" "OK" -}}
   {{- if .menu.IsHome -}}
     {{- $currentNode.Scratch.Set "prevPage" "" -}}


### PR DESCRIPTION
adds more C++ examples (like https://github.com/EnzymeAD/www/pull/15) and fixes a few typos

---------

Also, a recent version of `hugo` from homebrew is unable to build this website as this theme uses some outdated practices that have been deprecated in the last couple of years:

https://discourse.gohugo.io/t/cant-evaluate-field-hugo-in-hugolib-pagestate/37862/3

Knowing nothing about `hugo`, I just started replacing the files that produced error messages when running `hugo server` by their counterparts from the more up-to-date https://github.com/llvm/mlir-www/tree/main (that I imagine this theme is based on) until it built successfully.

------