### PR TITLE
fix link to installation guide from getting_started

### DIFF
--- a/content/getting_started/UsingEnzyme.md
+++ b/content/getting_started/UsingEnzyme.md
@@ -65,7 +65,7 @@ entry:
 ```
 
 ## Performing AD Enzyme
-We can now run Enzyme to differentiate our LLVM IR. The following command will load Enzyme and run the differentiation transformation pass. Note that `opt` should be the path to whatever opt was creating by the LLVM you built Enzyme against. If you see a segfault when trying to run opt, this is likely an issue in LLVM's plugin infrasture. Please see [the installation guide](/getting_started/Installation) for more information on how to resolve this. For LLVM 13 or a higher version, please see [FAQ](/getting_started/Faq).
+We can now run Enzyme to differentiate our LLVM IR. The following command will load Enzyme and run the differentiation transformation pass. Note that `opt` should be the path to whatever opt was creating by the LLVM you built Enzyme against. If you see a segfault when trying to run opt, this is likely an issue in LLVM's plugin infrasture. Please see [the installation guide](/Installation) for more information on how to resolve this. For LLVM 13 or a higher version, please see [FAQ](/getting_started/Faq).
 
 ```sh
 opt input.ll -load=/path/to/Enzyme/enzyme/build/Enzyme/LLVMEnzyme-<VERSION>.so -enzyme -o output.ll -S


### PR DESCRIPTION
It was giving error 404 since it assumed `Installation` is under `getting_started`, while it's one level up