### PR TITLE
remove wrong usage instructions

### DIFF
--- a/content/getting_started/Faq.md
+++ b/content/getting_started/Faq.md
@@ -13,28 +13,6 @@ Double check that Enzyme's build can find lit, LLVM's testing framework. This ca
 
 LLVM's plugin infrastructure is broken in many versions. Empirically LLVM 8 and up will often incorrectly disallow memory from being passed between LLVM and a plugin. If you see one of these errors and want to use the same version of LLVM try passing the flag `enzyme_preopt=0` described [here](/getting_started/UsingEnzyme). The flag disables preprocessing optimizations that Enzyme runs and tends to reduce these errors. If this doesn't work, check the following.
 
-### Illegal TypeAnalysis on LLVM 10+
-
-There is a [known bug](https://bugs.llvm.org/show_bug.cgi?id=47612) in an existing LLVM optimization pass (SROA) that will incorrectly generate type information from a memcpy. This bug has been fixed in LLVM 13
-
-### opt can't find -enzyme option
-
-When you use opt command like below:
-```sh
-opt input.ll -load=/path/to/LLVMEnzyme-VERSION.so -enzyme -o output.ll -S
-```
-opt reports a error:`opt: unknown pass name 'enzyme'`
-
-May be because you are using  LLVM 13 or a higher version, which has switched to the new pass manager pipeline. On applicable LLVM versions (up to and including LLVM 15),
-you can specify that opt useees the old pass manager by adding the `--enable-new-pm=0` flag. Alternatively, you can use the new pass manager, which uses the following syntax
-for opt:
-
-```sh
-opt input.ll -load-pass-plugin=/path/to/LLVMEnzyme-VERSION.so -passes=enzyme -o output.ll -S
-```
-
-If you are using CMake, Enzyme exports a special `ClangEnzymeFlags` target which will automatically add the correct flags. See [here](https://github.com/EnzymeAD/Enzyme/blob/main/enzyme/test/test_find_package/CMakeLists.txt#L14) for an example.
-
 ## I receive an `__enzime_autodiff` undefined symbol either at runtime or at compile time
 This error means that you have Enzyme calls which did not run the the Enzyme AD transformation. Please check that you have Enzyme run as part of the compilation which resulted in the error.
 In projects with multisource and/or complex building systems it's possible to overlook one source file being compiled/linked without the appropriate Enzyme plugin pass.

--- a/content/getting_started/UsingEnzyme.md
+++ b/content/getting_started/UsingEnzyme.md
@@ -65,10 +65,10 @@ entry:
 ```
 
 ## Performing AD Enzyme
-We can now run Enzyme to differentiate our LLVM IR. The following command will load Enzyme and run the differentiation transformation pass. Note that `opt` should be the path to whatever opt was creating by the LLVM you built Enzyme against. If you see a segfault when trying to run opt, this is likely an issue in LLVM's plugin infrasture. Please see [the installation guide](/Installation) for more information on how to resolve this. For LLVM 13 or a higher version, please see [FAQ](/getting_started/Faq).
+We can now run Enzyme to differentiate our LLVM IR. The following command will load Enzyme and run the differentiation transformation pass. Note that `opt` should be the path to whatever opt was creating by the LLVM you built Enzyme against. If you see a segfault when trying to run opt, this is likely an issue in LLVM's plugin infrasture. Please see [the installation guide](/Installation) for more information on how to resolve this.
 
 ```sh
-opt input.ll -load=/path/to/Enzyme/enzyme/build/Enzyme/LLVMEnzyme-<VERSION>.so -enzyme -o output.ll -S
+opt input.ll --load-pass-plugin=/path/to/Enzyme/enzyme/build/Enzyme/LLVMEnzyme-<VERSION>.so -passes=enzyme -o output.ll -S
 ```
 
 Taking a look at `output.ll`, we find the following:
@@ -144,7 +144,7 @@ Moreover, using Enzyme's clang plugin, we could automate the entire AD and compi
 clang test.c -fplugin=/path/to/Enzyme/enzyme/build/Enzyme/ClangEnzyme-<VERSION>.so -o a.exe
 ```
 
-Note that if using the LLVM plugin, each version of LLVM will have slightly different command line flags to specifying plugins. See [the FAQ](/getting_started/Faq) for more information. If using the clang plugin, the same command should work independently of version.
+Note that if using the LLVM plugin, each version of LLVM will have slightly different command line flags to specifying plugins. Please open an issue if you fail to run Enzyme. If using the clang plugin, the same command should work independently of version.
 
 ## Advanced options
 
@@ -157,8 +157,8 @@ Enzyme has several advanced options that may be of interest.
 The `enzyme-preopt` option disables the preprocessing optimizations run by the Enzyme pass, except for the absolute minimum neccessary.
 
 ```sh
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-preopt=1
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-preopt=0
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so -passes=enzyme -enzyme-preopt=1
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so -passes=enzyme -enzyme-preopt=0
 ```
 
 #### Forced Inlining
@@ -166,8 +166,8 @@ $ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-preopt=0
 The `enzyme-inline` option forcibly inlines all subfunction calls. The `enzyme-inline-count` option limits the number of calls inlined by this utility.
 
 ```sh
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-inline=1
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-inline=1 -enzyme-inline-count=100
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so -passes=enzyme -enzyme-inline=1
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so -passes=enzyme -enzyme-inline=1 -enzyme-inline-count=100
 ```
 
 #### Compressed Bool Cache
@@ -175,7 +175,7 @@ $ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-inline=1 -enzyme-i
 The `enzyme-smallbool` option allows Enzyme's cache to store 8 boolean (i1) values inside a single byte rather than one value per byte.
 
 ```sh
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-smallbool=1
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so -passes=enzyme -enzyme-smallbool=1
 ```
 
 ### Semantic options
@@ -185,7 +185,7 @@ $ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-smallbool=1
 The `enzyme-loose-types` option tells Enzyme to make an educated guess about the type of a value it cannot prove, rather than emit a compile-time error and fail. This can be helpful for starting to bootstrap code with Enzyme but shouldn't be used in production as Enzyme may make an incorrect guess and create an incorrect gradient.
 
 ```sh
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-loose-types=1
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so.so -passes=enzyme -enzyme-loose-types=1
 ```
 
 
@@ -194,7 +194,7 @@ $ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-loose-types=1
 The `enzyme-emptyfn-inactive` option tells activity analysis to assume that all calls to functions whose definitions aren't available and aren't explicitly given a custom gradient via metadata are assumed to be inactive. This can be useful for assuming printing functions don't impact derivative computations and provide a performance benefit, as well as getting around a compile-time error where the derivative of a foreign function is not known. However, this option should be used carefully as it may result in incorrect behavior if it is used to incorrectly assume a call to a foreign function doesn't impact  the derivative computation. As a result, the recommended way to remedy this is to mark the function as inactive explicitly, or provide a custom gradient via metadata.
 
 ```sh
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-emptyfn-inactive=1
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so.so -passes=enzyme -enzyme-emptyfn-inactive=1
 ```
 
 #### Assume inactivity of unmarked globals
@@ -202,7 +202,7 @@ $ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-emptyfn-inactive=1
 The `enzyme-globals-default-inactive` option tells activity analysis to assume that global variables without an explicitly defined shadow global are assumed to be inactive. Like `enzyme_emptyfnconst`, this option should be used carefully as it may result in incorrect behavior if it is used to incorrectly assume that a global variable doesn't contain data used in a derivative computation.
 
 ```sh
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-globals-default-inactive=1
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so.so -passes=enzyme -enzyme-globals-default-inactive=1
 ```
 
 #### Cache behavior
@@ -210,13 +210,13 @@ $ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-globals-default-in
 The `enzyme-cache-never` option tells the cache to recompute all load values, even if alias analysis isn't able to prove the legality of such a recomputation. This may improve performance but is likely to result in incorrect derivatives being produced as this is not generally true.
 
 ```sh
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-cache-never=1
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so.so -passes=enzyme -enzyme-cache-never=1
 ```
 
 In contrast, the `enzyme-cache-always` option tells the cache to still cache values that alias analysis and differential use analysis say are not needed to be cached (perhaps being legal to recompute instead). This will usually decrease performance and is intended for developers in order to catch caching bugs.
 
 ```sh
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-cache-always=1
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so.so -passes=enzyme -enzyme-cache-always=1
 ```
 
 ### Debugging options for developers
@@ -226,7 +226,7 @@ $ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-cache-always=1
 This option prints out functions being differentiated before preprocessing optimizations, after preprocessing optimizations, and after being synthesized by Enzyme. It is mostly use to debug the AD process.
 
 ```sh
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-print
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so.so -passes=enzyme -enzyme-print
 prefn:
 
 ; Function Attrs: norecurse nounwind readnone uwtable
@@ -242,7 +242,7 @@ entry:
 This option prints out the results of activity analysis as they are being derived. The output is somewaht specific to the analysis pass and is only intended for developers.
 
 ```sh
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-print-activity
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so.so -passes=enzyme -enzyme-print-activity
 in new function diffesquare nonconstant arg double %0
  VALUE nonconst from arg nonconst double %x
 checking if is constant[3]   %mul = fmul double %x, %x
@@ -259,7 +259,7 @@ couldnt decide nonconstants(3):  %mul = fmul double %x, %x
 This option prints out the results of type analysis as they are being derived. The output is somewaht specific to the analysis pass and is only intended for developers.
 
 ```sh
-$ opt input.ll -load=./Enzyme/LLVMEnzyme-7.so -enzyme -enzyme-print-type
+$ opt input.ll -load-pass-plugin=./Enzyme/LLVMEnzyme-17.so.so -passes=enzyme -enzyme-print-type
 analyzing function square
  + knowndata: double %x : {[-1]:Float@double} - {}
  + retdata: {}


### PR DESCRIPTION
@wsmoses I don't have capacity to engage further with this, so please feel free to update/close/merge it as you see fit.
But this is less wrong than what we had before.
If you have time to fix the -enzyme-print flags that would be great, I didn't got them to work so I left it as is.