### PR TITLE
make examples work for clang-19

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -21,6 +21,7 @@ int main() {
     // Evaluates to 2 * x = 6.28
     double grad_x = __enzyme_autodiff((void*)square, x);
     printf("square'(%f) = %f\n", x,  grad_x);
+    return 1;
 }
 ```
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -21,7 +21,7 @@ int main() {
     // Evaluates to 2 * x = 6.28
     double grad_x = __enzyme_autodiff((void*)square, x);
     printf("square'(%f) = %f\n", x,  grad_x);
-    return 1;
+    return 0;
 }
 ```
 

--- a/content/getting_started/CallingConvention.md
+++ b/content/getting_started/CallingConvention.md
@@ -22,7 +22,7 @@ double __enzyme_autodiffDouble(double (*)(double), double);
 int main() {
   printf("float  d/dx %f\n", __enzyme_autodiffFloat(square<float>, 1.0f));
   printf("double d/dx %f\n", __enzyme_autodiffDouble(square<double>, 1.0));
-  return 1;
+  return 0;
 }
 ```
 
@@ -85,7 +85,7 @@ int main() {
                        enzyme_dup  , array, d_array,
                        enzyme_const, size,
                        enzyme_out  , mul);
-  return 1;
+  return 0;
 }
 ```
 

--- a/content/getting_started/CallingConvention.md
+++ b/content/getting_started/CallingConvention.md
@@ -22,6 +22,7 @@ double __enzyme_autodiffDouble(double (*)(double), double);
 int main() {
   printf("float  d/dx %f\n", __enzyme_autodiffFloat(square<float>, 1.0f));
   printf("double d/dx %f\n", __enzyme_autodiffDouble(square<double>, 1.0));
+  return 1;
 }
 ```
 
@@ -84,6 +85,7 @@ int main() {
                        enzyme_dup  , array, d_array,
                        enzyme_const, size,
                        enzyme_out  , mul);
+  return 1;
 }
 ```
 

--- a/content/getting_started/UsingEnzyme.md
+++ b/content/getting_started/UsingEnzyme.md
@@ -36,7 +36,7 @@ double dsquare(double x) {
 int main() {
     for(double i=1; i<5; i++)
         printf("square(%f)=%f, dsquare(%f)=%f", i, square(i), i, dsquare(i));
-    return 1;
+    return 0;
 }
 ```
 

--- a/content/getting_started/UsingEnzyme.md
+++ b/content/getting_started/UsingEnzyme.md
@@ -36,6 +36,7 @@ double dsquare(double x) {
 int main() {
     for(double i=1; i<5; i++)
         printf("square(%f)=%f, dsquare(%f)=%f", i, square(i), i, dsquare(i));
+    return 1;
 }
 ```
 


### PR DESCRIPTION
Literally 
![image](https://github.com/user-attachments/assets/b037b612-f9a4-4038-96ce-1453a925c407)


I had some people struggling with C-Enzyme, because the examples failed.
Turnes out clang deleted the whole example code, because the `int main` function does return nothing, which is UB, 
which makes it ok to delete the whole code, which is what happened for them.
Yes it's an extra line for each example, but in turn the examples are not UB and will work for all users, so I think that's worth it.